### PR TITLE
Savegame Extractor

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -4,8 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>nl.paulinternet.gtasaveedit</groupId>
+        <artifactId>gtasaveedit</artifactId>
+        <version>3.3-SNAPSHOT</version>
+    </parent>
+
     <artifactId>cli</artifactId>
-    <groupId>nl.paulinternet.gtasaveedit</groupId>
     <version>3.3-SNAPSHOT</version>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
             <artifactId>jmdns</artifactId>
             <version>3.5.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             <version>0.8.9.8</version>
             <classifier>full</classifier>
         </dependency>
+        <dependency>
+            <groupId>org.jmdns</groupId>
+            <artifactId>jmdns</artifactId>
+            <version>3.5.4</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractedSavegameHolder.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractedSavegameHolder.java
@@ -1,16 +1,18 @@
 package nl.paulinternet.gtasaveedit.extractor;
 
-import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractedSaveGameMenu;
+import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractedSavegameSubmenu;
 import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractorMenu;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 
 public class ExtractedSavegameHolder {
     private static ExtractedSavegameHolder instance = null;
-    private final HashMap<Integer, ExtractorServer.ExtractedSavegameFile> saveGameFiles;
+    private final ArrayList<ExtractorServer.ExtractedSavegameFile> saveGameFiles;
+    private String selectedSavegame = "";
 
     private ExtractedSavegameHolder() {
-        saveGameFiles = new HashMap<>();
+        saveGameFiles = new ArrayList<>();
     }
 
     public static ExtractedSavegameHolder getInstance() {
@@ -20,12 +22,20 @@ public class ExtractedSavegameHolder {
         return instance;
     }
 
-    public static HashMap<Integer, ExtractorServer.ExtractedSavegameFile> getSaveGameFiles() {
+    public static ArrayList<ExtractorServer.ExtractedSavegameFile> getSaveGameFiles() {
         return getInstance().saveGameFiles;
     }
 
-    public static void addSavegame(Integer idx, ExtractorServer.ExtractedSavegameFile file, ExtractorMenu menu) {
-        getSaveGameFiles().put(idx, file);
-        menu.add(new ExtractedSaveGameMenu(file.getSaveGame(), file.getFileName()));
+    public static void addSavegame(ExtractorServer.ExtractedSavegameFile file, ExtractorMenu menu) {
+        getSaveGameFiles().add(file);
+        menu.add(new ExtractedSavegameSubmenu(file.getSaveGame(), file.getFileName()));
+    }
+
+    public String getSelectedSavegame() {
+        return selectedSavegame;
+    }
+
+    public void setSelectedSavegame(String selectedSavegame) {
+        this.selectedSavegame = selectedSavegame;
     }
 }

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractedSavegameHolder.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractedSavegameHolder.java
@@ -1,0 +1,31 @@
+package nl.paulinternet.gtasaveedit.extractor;
+
+import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractedSaveGameMenu;
+import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractorMenu;
+
+import java.util.HashMap;
+
+public class ExtractedSavegameHolder {
+    private static ExtractedSavegameHolder instance = null;
+    private final HashMap<Integer, ExtractorServer.ExtractedSavegameFile> saveGameFiles;
+
+    private ExtractedSavegameHolder() {
+        saveGameFiles = new HashMap<>();
+    }
+
+    public static ExtractedSavegameHolder getInstance() {
+        if (instance == null) {
+            instance = new ExtractedSavegameHolder();
+        }
+        return instance;
+    }
+
+    public static HashMap<Integer, ExtractorServer.ExtractedSavegameFile> getSaveGameFiles() {
+        return getInstance().saveGameFiles;
+    }
+
+    public static void addSavegame(Integer idx, ExtractorServer.ExtractedSavegameFile file, ExtractorMenu menu) {
+        getSaveGameFiles().put(idx, file);
+        menu.add(new ExtractedSaveGameMenu(file.getSaveGame(), file.getFileName()));
+    }
+}

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
@@ -1,0 +1,127 @@
+package nl.paulinternet.gtasaveedit.extractor;
+
+import com.sun.net.httpserver.HttpServer;
+import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractorMenu;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+public class ExtractorServer extends Thread {
+
+    private static HttpServer server = null;
+    private static Path tempDir = null;
+    private ExtractorMenu menu;
+
+    public ExtractorServer(ExtractorMenu menu) {
+        this.menu = menu;
+    }
+
+    @Override
+    public void run() {
+        if (server == null) {
+            try {
+                startServer();
+            } catch (IOException e) {
+                System.err.println("Unable to start savegame extractor server!");
+                e.printStackTrace();
+            }
+        } else {
+            System.err.println("Server already running! " + server.getAddress().toString());
+        }
+    }
+
+    private void startServer() throws IOException {
+        System.out.println("Starting server...");
+        tempDir = Files.createTempDirectory("gtasaseExtractor");
+        server = HttpServer.create(new InetSocketAddress(8181), 0);
+        server.createContext("/add", new FormDataHandler(d -> {
+            FormDataHandler.FileData[] fileData = (FormDataHandler.FileData[]) d.toArray();
+            for (int i = 0; i < fileData.length; i++) {
+                FormDataHandler.FileData f = fileData[i];
+                if (f.contentType.equals("application/octet-stream")) {
+                    File savegameFile = new File(tempDir.toFile().getAbsolutePath() + File.separator + f.fileName);
+                    try (FileOutputStream stream = new FileOutputStream(savegameFile)) {
+                        System.out.println("Writing file: '" + savegameFile.getAbsolutePath() + "'");
+                        stream.write(f.data);
+                        ExtractedSavegameHolder.addSavegame(ExtractorMenu.EXTRACTED_SAVEGAMES_START_IDX + i, new ExtractedSavegameFile(savegameFile, f.fileName), menu);
+                    } catch (IOException e) {
+                        System.err.println("Unable to write temp file!");
+                        e.printStackTrace();
+                    }
+                } else {
+                    System.out.println("Unknown part: {name: '" + f.name + "', value: '" + Arrays.toString(f.data) + "'}");
+                }
+            }
+        }));
+        server.createContext("/upload", httpExchange -> {
+            String response = "<html><head><title>GTASASE Uploader</title></head><body><form action=\"/add\" " +
+                    "method=\"POST\"enctype=\"multipart/form-data\">Select savegame to add:<input type=\"file\" " +
+                    "name=\"savegame\" id=\"savegame\"><input type=\"submit\" value=\"Upload\" name=\"submit\"> " +
+                    "</form></body></html>";
+            httpExchange.sendResponseHeaders(200, response.length());
+            OutputStream os = httpExchange.getResponseBody();
+            os.write(response.getBytes());
+            os.close();
+        });
+        server.createContext("/list", httpExchange -> {
+            StringBuilder builder = new StringBuilder("[");
+            ExtractedSavegameHolder.getSaveGameFiles().forEach((i, f) -> {
+                String saveGameUrl = server.getAddress().toString() + "/get/" + f.getFileName();
+                builder.append("{\"id\": \"").append(i)
+                        .append("\", \"name\": \"").append(f.fileName)
+                        .append("\", \"uri\": \"").append(saveGameUrl)
+                        .append("\"},");
+            });
+            builder.append("]");
+            String response = builder.toString().replaceAll(",]", "");
+            httpExchange.sendResponseHeaders(200, response.length());
+            OutputStream os = httpExchange.getResponseBody();
+            os.write(response.getBytes());
+            os.close();
+        });
+        server.createContext("/version", httpExchange -> {
+            String response = "1";
+            httpExchange.sendResponseHeaders(200, response.length());
+            OutputStream os = httpExchange.getResponseBody();
+            os.write(response.getBytes());
+            os.close();
+        });
+        server.setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
+        server.start();
+    }
+
+    public void stopServer() {
+        if (server != null) {
+            System.out.println("Stopping server...");
+            server.stop(0);
+            server = null;
+            tempDir = null;
+        } else {
+            System.out.println("Server already stopped!");
+        }
+    }
+
+    public static class ExtractedSavegameFile {
+        private final File saveGame;
+        private final String fileName;
+
+        public ExtractedSavegameFile(File saveGame, String fileName) {
+            this.saveGame = saveGame;
+            this.fileName = fileName;
+        }
+
+        public File getSaveGame() {
+            return saveGame;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+    }
+}

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
@@ -1,27 +1,25 @@
 package nl.paulinternet.gtasaveedit.extractor;
 
 import com.sun.net.httpserver.HttpServer;
+import nl.paulinternet.gtasaveedit.view.Main;
 import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractorMenu;
 import nl.paulinternet.gtasaveedit.view.window.MainWindow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
 import javax.swing.*;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
+import java.io.*;
+import java.net.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.*;
 
 public class ExtractorServer extends Thread {
 
-    public static final String PROTO_VERSION = "1";
+    private static final Logger log = LoggerFactory.getLogger(ExtractorServer.class);
+    private static final String PROTO_VERSION = "1";
     private static HttpServer server = null;
     private static Path tempDir = null;
     private ExtractorMenu menu;
@@ -40,24 +38,27 @@ public class ExtractorServer extends Thread {
                 JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to start savegame extractor server!", JOptionPane.ERROR_MESSAGE);
             }
         } else {
-            System.err.println("Server already running! " + server.getAddress().toString());
+            log.error("Server already running! " + server.getAddress().toString());
         }
     }
 
     private void startServer() throws IOException {
-        System.out.println("Starting server...");
+        String hostAddress = InetAddress.getLocalHost().getHostAddress();
+        log.info("Starting server on '" + hostAddress + "'");
         tempDir = Files.createTempDirectory("gtasaseExtractor");
-        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server = HttpServer.create(new InetSocketAddress(hostAddress,0), 0);
         server.createContext("/add", new FormDataHandler(d -> {
             Object[] fileData = d.toArray();
+            //noinspection ForLoopReplaceableByForEach it's prettier this way
             for (int i = 0; i < fileData.length; i++) {
                 FormDataHandler.FileData f = (FormDataHandler.FileData) fileData[i];
                 if (f.contentType.equals("application/octet-stream")) {
                     File savegameFile = new File(tempDir.toFile().getAbsolutePath() + File.separator + f.fileName);
                     try (FileOutputStream stream = new FileOutputStream(savegameFile)) {
-                        System.out.println("Writing file: '" + savegameFile.getAbsolutePath() + "'");
+                        log.info("Writing file: '" + savegameFile.getAbsolutePath() + "'");
                         stream.write(f.data);
                         ExtractedSavegameHolder.addSavegame(new ExtractedSavegameFile(savegameFile, f.fileName), menu);
+                        JOptionPane.showMessageDialog(MainWindow.getInstance(), "Received file: '" + savegameFile.getName() + "' successfully.", "Savegame Received", JOptionPane.INFORMATION_MESSAGE);
                     } catch (IOException e) {
                         JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to write temp file!", JOptionPane.ERROR_MESSAGE);
                     }
@@ -107,29 +108,32 @@ public class ExtractorServer extends Thread {
         });
         server.setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
         server.start();
-        if(jmdns == null) {
-            jmdns = JmDNS.create(InetAddress.getLocalHost());
+
+        if (jmdns == null) {
+            jmdns = JmDNS.create(hostAddress);
         }
         HashMap<String, String> props = new HashMap<>();
         props.put("version", PROTO_VERSION);
+        props.put("ip", hostAddress);
+        props.put("port", String.valueOf(server.getAddress().getPort()));
         try {
             props.put("hostname", InetAddress.getLocalHost().getHostName());
         } catch (UnknownHostException e) {
             JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to get hostname!", JOptionPane.ERROR_MESSAGE);
         }
-        ServiceInfo serviceInfo = ServiceInfo.create("_gtasa-se._tcp.local.", "extractor", server.getAddress().getPort(), 0, 0, props);
+        ServiceInfo serviceInfo = ServiceInfo.create("_gtasa-se._tcp.local.", hostAddress.replaceAll("\\.","-"), server.getAddress().getPort(), 0, 0, props);
         jmdns.registerService(serviceInfo);
     }
 
     public void stopServer() {
         if (server != null) {
-            System.out.println("Stopping server...");
+            log.info("Stopping server...");
             server.stop(0);
             jmdns.unregisterAllServices();
             server = null;
             tempDir = null;
         } else {
-            System.out.println("Server already stopped!");
+            log.warn("Server already stopped!");
         }
     }
 

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
@@ -2,7 +2,9 @@ package nl.paulinternet.gtasaveedit.extractor;
 
 import com.sun.net.httpserver.HttpServer;
 import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractorMenu;
+import nl.paulinternet.gtasaveedit.view.window.MainWindow;
 
+import javax.swing.*;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -28,8 +30,7 @@ public class ExtractorServer extends Thread {
             try {
                 startServer();
             } catch (IOException e) {
-                System.err.println("Unable to start savegame extractor server!");
-                e.printStackTrace();
+                JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to start savegame extractor server!", JOptionPane.ERROR_MESSAGE);
             }
         } else {
             System.err.println("Server already running! " + server.getAddress().toString());
@@ -51,8 +52,7 @@ public class ExtractorServer extends Thread {
                         stream.write(f.data);
                         ExtractedSavegameHolder.addSavegame(new ExtractedSavegameFile(savegameFile, f.fileName), menu);
                     } catch (IOException e) {
-                        System.err.println("Unable to write temp file!");
-                        e.printStackTrace();
+                        JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to write temp file!", JOptionPane.ERROR_MESSAGE);
                     }
                 } else {
                     System.out.println("Unknown part: {name: '" + f.name + "', value: '" + Arrays.toString(f.data) + "'}");
@@ -91,8 +91,7 @@ public class ExtractorServer extends Thread {
                     httpExchange.sendResponseHeaders(200, f.saveGame.length());
                     os.write(Files.readAllBytes(f.saveGame.toPath()));
                 } catch (IOException e) {
-                    System.err.println("Unable to send file!");
-                    e.printStackTrace();
+                    JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to send file!", JOptionPane.ERROR_MESSAGE);
                 }
             }
         }));

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
@@ -78,12 +78,8 @@ public class ExtractorServer extends Thread {
         });
         server.createContext("/list", httpExchange -> {
             StringBuilder builder = new StringBuilder("[");
-            ExtractedSavegameHolder.getSaveGameFiles().forEach(f -> {
-                String saveGameUrl = server.getAddress().toString() + "/get/" + f.getFileName();
-                builder.append("{\"name\": \"").append(f.fileName)
-                        .append("\", \"uri\": \"").append(saveGameUrl)
-                        .append("\"},");
-            });
+            ExtractedSavegameHolder.getSaveGameFiles().forEach(f ->
+                    builder.append("{\"name\": \"").append(f.fileName).append("\"},"));
             builder.append("]");
             String response = builder.toString().replaceAll(",]", "]");
             httpExchange.sendResponseHeaders(200, response.length());

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/ExtractorServer.java
@@ -17,6 +17,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 
 public class ExtractorServer extends Thread {
 
@@ -46,7 +47,7 @@ public class ExtractorServer extends Thread {
     private void startServer() throws IOException {
         System.out.println("Starting server...");
         tempDir = Files.createTempDirectory("gtasaseExtractor");
-        server = HttpServer.create(new InetSocketAddress(8181), 0);
+        server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/add", new FormDataHandler(d -> {
             Object[] fileData = d.toArray();
             for (int i = 0; i < fileData.length; i++) {
@@ -113,7 +114,14 @@ public class ExtractorServer extends Thread {
         if(jmdns == null) {
             jmdns = JmDNS.create(InetAddress.getLocalHost());
         }
-        ServiceInfo serviceInfo = ServiceInfo.create("_gtasa-se._tcp.local.", "extractor", 8181, "version=" + PROTO_VERSION);
+        HashMap<String, String> props = new HashMap<>();
+        props.put("version", PROTO_VERSION);
+        try {
+            props.put("hostname", InetAddress.getLocalHost().getHostName());
+        } catch (UnknownHostException e) {
+            JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to get hostname!", JOptionPane.ERROR_MESSAGE);
+        }
+        ServiceInfo serviceInfo = ServiceInfo.create("_gtasa-se._tcp.local.", "extractor", server.getAddress().getPort(), 0, 0, props);
         jmdns.registerService(serviceInfo);
     }
 

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/FormDataHandler.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/FormDataHandler.java
@@ -141,9 +141,9 @@ public class FormDataHandler implements HttpHandler {
             } else {
                 exchange.sendResponseHeaders(200, 0); // OK
             }
+            handler.handle(files);
             exchange.getResponseBody().close();
             exchange.getRequestBody().close();
-            handler.handle(files);
         } catch (IOException e) {
             System.err.println("Unable to handle request!");
             e.printStackTrace();

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/FormDataHandler.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/FormDataHandler.java
@@ -13,6 +13,9 @@ import java.util.regex.Pattern;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import nl.paulinternet.gtasaveedit.view.window.MainWindow;
+
+import javax.swing.*;
 
 public class FormDataHandler implements HttpHandler {
     private static final int MAX_SIZE = 1024 * 1024 * 5; // 5MB
@@ -113,7 +116,7 @@ public class FormDataHandler implements HttpHandler {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), e.getClass().getName(), JOptionPane.ERROR_MESSAGE);
         } finally {
             sendResponse(exchange);
         }
@@ -125,7 +128,7 @@ public class FormDataHandler implements HttpHandler {
         try {
             file.data = readAll(is);
         } catch (IOException e) {
-            e.printStackTrace();
+            JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), e.getClass().getName(), JOptionPane.ERROR_MESSAGE);
         }
         if (file.data.length >= 0) {
             System.out.println(String.format("  Received: %d bytes", file.data.length));
@@ -145,8 +148,7 @@ public class FormDataHandler implements HttpHandler {
             exchange.getResponseBody().close();
             exchange.getRequestBody().close();
         } catch (IOException e) {
-            System.err.println("Unable to handle request!");
-            e.printStackTrace();
+            JOptionPane.showMessageDialog(MainWindow.getInstance(), e.getMessage(), "Unable to handle Request", JOptionPane.ERROR_MESSAGE);
         }
     }
 

--- a/src/main/java/nl/paulinternet/gtasaveedit/extractor/FormDataHandler.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/extractor/FormDataHandler.java
@@ -1,0 +1,267 @@
+package nl.paulinternet.gtasaveedit.extractor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+public class FormDataHandler implements HttpHandler {
+    private static final int MAX_SIZE = 1024 * 1024 * 5; // 5MB
+    private Pattern namePattern = Pattern.compile("[^e]name=\"(.+?)\"");
+    private Pattern fileNamePattern = Pattern.compile("filename=\"(.+?)\"");
+    private String escapedSeparator = "\\" + System.getProperty("file.separator");
+    private int part;
+    private boolean allRead;
+    private boolean sizeExceeded;
+    protected Set<FileData> files;
+    private Handler handler;
+
+    public FormDataHandler(Handler handler) {
+        this.handler = handler;
+    }
+
+    /**
+     * @see <a href="http://tools.ietf.org/html/rfc1867">RFC 1867</a>
+     */
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+
+        System.out.println("--- Parsing form submission.");
+        part = 0;
+        allRead = false;
+        sizeExceeded = false;
+        files = new HashSet<>();
+        String path = exchange.getRequestURI().getPath();
+        System.out.println(String.format("Requested URI: %s", path));
+
+        // Get content type.
+        // e.g.
+        // multipart/form-data, boundary=AaB03x
+        List<String> contentTypes = exchange.getRequestHeaders().get("Content-Type");
+        String contentType = null;
+        String boundary = null;
+        if (contentTypes != null && contentTypes.size() > 0) {
+            contentType = contentTypes.get(0);
+            if (contentType.startsWith("multipart/form-data;")) {
+                String[] params = contentType.split("boundary=");
+                boundary = params[params.length - 1];
+            }
+            System.out.println(String.format("Content type: %s", contentType));
+        }
+
+        // Handle single image post.
+        if (contentType != null && contentType.startsWith("image/")) {
+            handlePostedSingleImage(contentType, exchange);
+            return;
+        }
+
+        // Return error 400.
+        if (!"post".equalsIgnoreCase(exchange.getRequestMethod())
+                || contentType == null
+                || boundary == null) {
+            exchange.sendResponseHeaders(400, 0); // Bad request
+            exchange.getResponseBody().close();
+            System.err.println("Bad request.");
+            return;
+        }
+
+        // Parse form submission.
+        String boundaryLine = "--" + boundary;
+        InputStream is = exchange.getRequestBody();
+        try {
+            while (!allRead) {
+
+                // Wait for the boundary.
+                String currentLine = readLine(is);
+                if (!currentLine.equals(boundaryLine)) {
+                    continue;
+                }
+
+                // Read disposition.
+                FileData file = new FileData();
+                readDisposition(is, file);
+                if (file.fileName == null) {
+                    // Skip none-file contents.
+                    continue;
+                }
+                files.add(file);
+
+                // Get content type and wait for a blank line.
+                readContentType(is, file);
+                System.out.println(String.format("  Content type: %s", file.contentType));
+
+                // Get file contents.
+                byte[] boundaryBytes = ("\r\n" + boundaryLine).getBytes(StandardCharsets.UTF_8);
+                file.data = readUntil(is, boundaryBytes);
+                if (file.data.length >= 0) {
+                    System.out.println(String.format("  Received: %d bytes", file.data.length));
+                    currentLine = readLine(is);
+
+                    // Check if this is the last part.
+                    if (currentLine.equals("--")) {
+                        break;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            sendResponse(exchange);
+        }
+    }
+
+    private void handlePostedSingleImage(String contentType, HttpExchange exchange) {
+        FileData file = new FileData();
+        InputStream is = exchange.getRequestBody();
+        try {
+            file.data = readAll(is);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        if (file.data.length >= 0) {
+            System.out.println(String.format("  Received: %d bytes", file.data.length));
+            files.add(file);
+        }
+        sendResponse(exchange);
+    }
+
+    private void sendResponse(HttpExchange exchange) {
+        try {
+            if (sizeExceeded) {
+                exchange.sendResponseHeaders(400, 0); // Bad request
+            } else {
+                exchange.sendResponseHeaders(200, 0); // OK
+            }
+            exchange.getResponseBody().close();
+            exchange.getRequestBody().close();
+            handler.handle(files);
+        } catch (IOException e) {
+            System.err.println("Unable to handle request!");
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Get content type and wait for a blank line.
+     * <p>
+     * e.g.
+     * Content-Type: image/gif
+     *
+     * @param is
+     * @param file
+     * @throws IOException
+     */
+    private void readContentType(InputStream is, FileData file) throws IOException {
+        while (true) {
+            String currentLine = readLine(is);
+
+            // Wait for a blank line.
+            if (currentLine.equals("")) {
+                break;
+            }
+
+            // Get content type.
+            if (currentLine.toLowerCase().startsWith("content-type:")) {
+                int spaceIndex = currentLine.indexOf(' ');
+                if (spaceIndex < 0) {
+                    file.contentType = null;
+                } else {
+                    file.contentType = currentLine.substring(spaceIndex + 1);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get content disposition.
+     * <p>
+     * e.g.
+     * content-disposition: form-data; name="pics"; filename="file1.txt"
+     *
+     * @param is
+     * @param data
+     * @throws IOException
+     */
+    private void readDisposition(InputStream is, FileData data) throws IOException {
+        String disposition = readLine(is);
+        Matcher m;
+        m = namePattern.matcher(disposition);
+        if (m.find()) {
+            data.name = m.group(1);
+        }
+        m = fileNamePattern.matcher(disposition);
+        if (m.find()) {
+            data.fileName = m.group(1);
+            int lastSeparator = data.fileName.lastIndexOf(escapedSeparator);
+            if (lastSeparator >= 0) {
+                data.fileName = data.fileName.substring(
+                        lastSeparator + escapedSeparator.length());
+            }
+        }
+
+        System.out.println(String.format("Part.%d", ++part));
+        System.out.println(String.format("  Name: %s", data.name));
+        System.out.println(String.format("  File name: %s", data.fileName));
+    }
+
+    private String readLine(InputStream is) throws IOException {
+        String line = new String(readUntil(is, "\r\n".getBytes()), "utf-8");
+        // System.err.println(line);
+        return line;
+    }
+
+    private byte[] readAll(InputStream is) throws IOException {
+        return readUntil(is, null);
+    }
+
+    private byte[] readUntil(InputStream is, byte[] tail) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        int b = -1;
+        byte[] current = tail != null ? new byte[tail.length] : null;
+        byte[] data = null;
+        while (!allRead && (b = is.read()) >= 0) {
+            bos.write(b);
+            if (current != null) {
+                System.arraycopy(current, 1, current, 0, current.length - 1);
+                current[current.length - 1] = (byte) b;
+                if (Arrays.equals(tail, current)) {
+                    byte[] rawData = bos.toByteArray();
+                    data = new byte[rawData.length - tail.length];
+                    System.arraycopy(rawData, 0, data, 0, data.length);
+                    break;
+                }
+            }
+            if (bos.size() >= MAX_SIZE) {
+                sizeExceeded = true;
+                break;
+            }
+        }
+        if (b < 0) {
+            allRead = true;
+        }
+        if (data == null) {
+            data = bos.toByteArray();
+        }
+        return data;
+    }
+
+    public static class FileData {
+        public String name;
+        public String fileName;
+        public String contentType;
+        public byte[] data;
+    }
+
+    public interface Handler {
+        void handle(Set<FileData> files);
+    }
+}

--- a/src/main/java/nl/paulinternet/gtasaveedit/model/savegame/SavegameData.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/model/savegame/SavegameData.java
@@ -15,183 +15,197 @@ import java.net.URL;
 import java.util.zip.CheckedOutputStream;
 import java.util.zip.Checksum;
 
-public class SavegameData
-{
-	public static final int FILESIZE = 202752;
-	public static final byte[] BLOCK = new byte[] {66, 76, 79, 67, 75};
-	
-	private ByteSequence[] block = new ByteSequence[30];
-	
-	public SavegameData () {}
+public class SavegameData {
+    public static final int FILESIZE = 202752;
+    public static final int FILESIZE_ANDROID = 195002;
+    public static final byte[] BLOCK = new byte[]{66, 76, 79, 67, 75};
 
-	public SavegameData (File filename) throws IOException, FileFormatException {
-		// Read the data
-		RandomAccessFile file = null;
-		byte[] bytes;
-		try {
-			file = new RandomAccessFile(filename, "r");
-			if (file.length() != FILESIZE) throw new FileFormatException();
-			bytes = new byte[FILESIZE - 4];
-			file.readFully(bytes);
-		} finally {
-			try {file.close();} catch (Exception e) {}
-		}
+    private ByteSequence[] block = new ByteSequence[30];
 
-		// Init
-		init(bytes);
-	}
-	
-	public SavegameData (URL url) {
-		try {
-			byte[] bytes = new byte[FILESIZE - 4];
-			
-			DataInputStream in = new DataInputStream(url.openStream());
-			in.readFully(bytes);
-			in.close();
-			
-			init(bytes);
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-	
-	private void init (byte[] bytes) throws IOException, FileFormatException {
-		// Search every occurrence of "BLOCK"
-		int pos = 0;
-		int[] blockPos = new int[34];
-		for (int i=0; i<34; i++) {
-			blockPos[i] = Util.indexOf(bytes, BLOCK, pos);
-			if (blockPos[i] == -1) throw new FileFormatException();
-			pos = blockPos[i] + BLOCK.length;
-		}
-		
-		// Check if the file starts with "BLOCK"
-		if (blockPos[0] != 0) throw new FileFormatException();
-		
-		// Check length of block 10
-		if (blockPos[11] - blockPos[10] - 5 != 18892) throw new FileFormatException();
-		
-		// Extract the blocks
-		ByteSequence data = new ByteSequence(bytes);
+    public SavegameData() {
+    }
 
-		for (int i=0; i<block.length; i++) {
-			block[i] = data.getSubSequence(blockPos[i] + BLOCK.length, blockPos[i+1]);
-		}
-	}
-	
-	public ByteSequence[] getBlocks () {
-		return block;
-	}
-	
-	public ByteSequence getBlock (int block) {
-		return this.block[block];
-	}
+    public SavegameData(File filename) throws IOException, FileFormatException {
+        // Read the data
+        RandomAccessFile file = null;
+        byte[] bytes;
+        try {
+            file = new RandomAccessFile(filename, "r");
+            if (file.length() == FILESIZE) {
+                bytes = new byte[FILESIZE - 4];
+            } else if (file.length() == FILESIZE_ANDROID) {
+                bytes = new byte[FILESIZE_ANDROID - 4];
+            } else {
+                throw new FileFormatException();
+            }
 
-	public void setBlock (int block, ByteSequence data) {
-		this.block[block] = data;
-	}
+            file.readFully(bytes);
+        } finally {
+            try {
+                file.close();
+            } catch (Exception e) {
+            }
+        }
 
-	public void save (File file) throws IOException {
-		OutputStream out = null;
-		try {
-			// Open file
-			Checksum checksum = new SumOfBytes();
-			out = new CheckedOutputStream(new BufferedOutputStream(new FileOutputStream(file)), checksum);
-			
-			// Write blocks
-			int pos = 0;
-			
-			for (int i=0; i<30; i++) {
-				out.write(BLOCK);
-				block[i].writeContents(out);
-				pos += BLOCK.length + block[i].getLength();
-			}
-			
-			for (int i=15; i<18; i++) {
-				out.write(BLOCK);
-				block[i].writeContents(out);
-				pos += BLOCK.length + block[i].getLength();
-			}
-			
-			// Write padding
-			out.write(BLOCK);
-			pos += BLOCK.length;
-			out.write(new byte[FILESIZE - 4 - pos]);
-	
-			// Write checksum
-			int checkSumValue = (int) checksum.getValue();
-			out.write(checkSumValue);
-			out.write(checkSumValue >> 8);
-			out.write(checkSumValue >> 16);
-			out.write(checkSumValue >> 24);
-		} finally {
-			try {out.close();} catch (Exception e) {}
-		}
-	}
-	
-	public int readInt (int block, int pos, int size) {
-		// Get data
-		byte[] bytes = this.block[block].getBytes(pos, pos + size);
-		
-		// Convert it to an integer
-		int number = 0;
-		for (int i=0; i<size; i++) {
-			number |= (bytes[i] & 0xff) << i * 8;
-		}
-		
-		// Return
-		return number;
-	}
-	
-	public void writeInt (int block, int pos, int size, int value) {
-		// Create a byte array
-		byte[] bytes = new byte[size];
-		for (int i=0; i<size; i++) {
-			bytes[i] = (byte) (value >> i * 8);
-		}
-		
-		// Overwrite the data
-		this.block[block].overwrite(bytes, pos);
-	}
-	
-	public int readInt (int block, int pos) {
-		return readInt(block, pos, 4);
-	}
-	
-	public void writeInt (int block, int pos, int value) {
-		writeInt(block, pos, 4, value);
-	}
-	
-	public short readShort (int block, int pos) {
-		return (short) readInt(block, pos, 2);
-	}
-	
-	public void writeShort (int block, int pos, int value) {
-		writeInt(block, pos, 2, value);
-	}
-	
-	public int readByte (int block, int pos) {
-		return readInt(block, pos, 1);
-	}
-	
-	public void writeByte (int block, int pos, int value) {
-		writeInt(block, pos, 1, value);
-	}
-	
-	public boolean readBoolean (int block, int pos) {
-		return readInt(block, pos, 1) != 0;
-	}
-	
-	public void writeBoolean (int block, int pos, boolean value) {
-		writeInt(block, pos, 1, value ? 1 : 0);
-	}
-	
-	public float readFloat (int block, int pos) {
-		return Float.intBitsToFloat(readInt(block, pos));
-	}
-	
-	public void writeFloat (int block, int pos, float value) {
-		writeInt(block, pos, Float.floatToRawIntBits(value));
-	}
+        // Init
+        init(bytes);
+    }
+
+    public SavegameData(URL url) {
+        try {
+            byte[] bytes = new byte[FILESIZE - 4];
+
+            DataInputStream in = new DataInputStream(url.openStream());
+            in.readFully(bytes);
+            in.close();
+
+            init(bytes);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void init(byte[] bytes) throws IOException, FileFormatException {
+        // Search every occurrence of "BLOCK"
+        int pos = 0;
+        int[] blockPos = new int[34];
+        for (int i = 0; i < 34; i++) {
+            blockPos[i] = Util.indexOf(bytes, BLOCK, pos);
+            if (blockPos[i] == -1) {
+                throw new FileFormatException();
+            }
+            pos = blockPos[i] + BLOCK.length;
+        }
+
+        // Check if the file starts with "BLOCK"
+        if (blockPos[0] != 0) throw new FileFormatException();
+
+        // Check length of block 10
+        if (blockPos[11] - blockPos[10] - 5 != 18892) throw new FileFormatException();
+
+        // Extract the blocks
+        ByteSequence data = new ByteSequence(bytes);
+
+        for (int i = 0; i < block.length; i++) {
+            block[i] = data.getSubSequence(blockPos[i] + BLOCK.length, blockPos[i + 1]);
+        }
+    }
+
+    public ByteSequence[] getBlocks() {
+        return block;
+    }
+
+    public ByteSequence getBlock(int block) {
+        return this.block[block];
+    }
+
+    public void setBlock(int block, ByteSequence data) {
+        this.block[block] = data;
+    }
+
+    public void save(File file) throws IOException {
+        OutputStream out = null;
+        try {
+            // Open file
+            Checksum checksum = new SumOfBytes();
+            out = new CheckedOutputStream(new BufferedOutputStream(new FileOutputStream(file)), checksum);
+
+            // Write blocks
+            int pos = 0;
+
+            for (int i = 0; i < 30; i++) {
+                out.write(BLOCK);
+                block[i].writeContents(out);
+                pos += BLOCK.length + block[i].getLength();
+            }
+
+            for (int i = 15; i < 18; i++) {
+                out.write(BLOCK);
+                block[i].writeContents(out);
+                pos += BLOCK.length + block[i].getLength();
+            }
+
+            // Write padding
+            out.write(BLOCK);
+            pos += BLOCK.length;
+            out.write(new byte[FILESIZE - 4 - pos]);
+
+            // Write checksum
+            int checkSumValue = (int) checksum.getValue();
+            out.write(checkSumValue);
+            out.write(checkSumValue >> 8);
+            out.write(checkSumValue >> 16);
+            out.write(checkSumValue >> 24);
+        } finally {
+            try {
+                out.close();
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    public int readInt(int block, int pos, int size) {
+        // Get data
+        byte[] bytes = this.block[block].getBytes(pos, pos + size);
+
+        // Convert it to an integer
+        int number = 0;
+        for (int i = 0; i < size; i++) {
+            number |= (bytes[i] & 0xff) << i * 8;
+        }
+
+        // Return
+        return number;
+    }
+
+    public void writeInt(int block, int pos, int size, int value) {
+        // Create a byte array
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) (value >> i * 8);
+        }
+
+        // Overwrite the data
+        this.block[block].overwrite(bytes, pos);
+    }
+
+    public int readInt(int block, int pos) {
+        return readInt(block, pos, 4);
+    }
+
+    public void writeInt(int block, int pos, int value) {
+        writeInt(block, pos, 4, value);
+    }
+
+    public short readShort(int block, int pos) {
+        return (short) readInt(block, pos, 2);
+    }
+
+    public void writeShort(int block, int pos, int value) {
+        writeInt(block, pos, 2, value);
+    }
+
+    public int readByte(int block, int pos) {
+        return readInt(block, pos, 1);
+    }
+
+    public void writeByte(int block, int pos, int value) {
+        writeInt(block, pos, 1, value);
+    }
+
+    public boolean readBoolean(int block, int pos) {
+        return readInt(block, pos, 1) != 0;
+    }
+
+    public void writeBoolean(int block, int pos, boolean value) {
+        writeInt(block, pos, 1, value ? 1 : 0);
+    }
+
+    public float readFloat(int block, int pos) {
+        return Float.intBitsToFloat(readInt(block, pos));
+    }
+
+    public void writeFloat(int block, int pos, float value) {
+        writeInt(block, pos, Float.floatToRawIntBits(value));
+    }
 }

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/FileDelete.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/FileDelete.java
@@ -36,21 +36,22 @@ class FileDelete extends JMenuItem implements ActionListener
 			File[] files = fileChooser.getSelectedFiles();
 			if (Settings.getWarnOverwriteFile() == Settings.YES) {
 				// Construct message
-				String message, title;
+				StringBuilder message;
+				String title;
 				if (files.length == 1) {
 					title = "Delete file?";
-					message = "Are you sure you want to delete the file \"" + files[0] + "\"?";
+					message = new StringBuilder("Are you sure you want to delete the file \"" + files[0] + "\"?");
 				}
 				else {
 					title = "Delete files?";
-					message = "Are you sure you want to delete the following files?";
-					for (File file : files) message += "\n" + file;
+					message = new StringBuilder("Are you sure you want to delete the following files?");
+					for (File file : files) message.append("\n").append(file);
 				}
 
 				// Show dialog
 				result = JOptionPane.showConfirmDialog(
 					MainWindow.getInstance(),
-					message,
+						message.toString(),
 					title,
 					JOptionPane.YES_NO_OPTION,
 					JOptionPane.WARNING_MESSAGE

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/MenuBar.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/MenuBar.java
@@ -4,6 +4,7 @@ import nl.paulinternet.gtasaveedit.model.io.FileSystem;
 import nl.paulinternet.gtasaveedit.model.Model;
 import nl.paulinternet.gtasaveedit.model.savegame.Savegame;
 import nl.paulinternet.gtasaveedit.view.Main;
+import nl.paulinternet.gtasaveedit.view.menu.extractor.ExtractorMenu;
 import nl.paulinternet.gtasaveedit.view.window.MainWindow;
 
 import javax.swing.*;
@@ -157,11 +158,15 @@ public class MenuBar extends JMenuBar {
             menuDelete.add(new QuickDelete(i));
         }
 
+        // Extractor menu
+        JMenu menuExtractor = new ExtractorMenu();
+
         // Add menus
         add(menuFile);
         add(menuLoad);
         add(menuSave);
         add(menuDelete);
+        add(menuExtractor);
 
         // set initial state
         menuSave.setEnabled(false);

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractedSaveGameMenu.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractedSaveGameMenu.java
@@ -1,0 +1,55 @@
+package nl.paulinternet.gtasaveedit.view.menu.extractor;
+
+import nl.paulinternet.gtasaveedit.model.exceptions.ErrorMessageException;
+import nl.paulinternet.gtasaveedit.model.savegame.Savegame;
+import nl.paulinternet.gtasaveedit.view.window.MainWindow;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+
+public class ExtractedSaveGameMenu extends JMenu {
+    private final File savegameFile;
+
+    public ExtractedSaveGameMenu(File savegameFile, String savegameName) {
+        this.savegameFile = savegameFile;
+        setText(savegameName);
+        add(new LoadExtractedSaveGameItem());
+        add(new SaveExtractedSaveGameItem());
+    }
+
+    public class SaveExtractedSaveGameItem extends JMenuItem implements ActionListener {
+
+        public SaveExtractedSaveGameItem() {
+            addActionListener(this);
+            setText("Save");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            try {
+                Savegame.save(savegameFile);
+            } catch (ErrorMessageException ex) {
+                JOptionPane.showMessageDialog(MainWindow.getInstance(), ex.getMessage(), ex.getTitle(), JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+
+    public class LoadExtractedSaveGameItem extends JMenuItem implements ActionListener {
+
+        public LoadExtractedSaveGameItem() {
+            addActionListener(this);
+            setText("Load");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            try {
+                Savegame.load(savegameFile);
+            } catch (ErrorMessageException ex) {
+                JOptionPane.showMessageDialog(MainWindow.getInstance(), ex.getMessage(), ex.getTitle(), JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractedSavegameSubmenu.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractedSavegameSubmenu.java
@@ -1,5 +1,6 @@
 package nl.paulinternet.gtasaveedit.view.menu.extractor;
 
+import nl.paulinternet.gtasaveedit.extractor.ExtractedSavegameHolder;
 import nl.paulinternet.gtasaveedit.model.exceptions.ErrorMessageException;
 import nl.paulinternet.gtasaveedit.model.savegame.Savegame;
 import nl.paulinternet.gtasaveedit.view.window.MainWindow;
@@ -9,19 +10,28 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 
-public class ExtractedSaveGameMenu extends JMenu {
+public class ExtractedSavegameSubmenu extends JMenu {
     private final File savegameFile;
+    private final String savegameName;
 
-    public ExtractedSaveGameMenu(File savegameFile, String savegameName) {
+    public ExtractedSavegameSubmenu(File savegameFile, String savegameName) {
         this.savegameFile = savegameFile;
-        setText(savegameName);
-        add(new LoadExtractedSaveGameItem());
-        add(new SaveExtractedSaveGameItem());
+        this.savegameName = savegameName;
+        setText(this.savegameName);
+
+        SaveExtractedSaveGameItem saveGameItem = new SaveExtractedSaveGameItem();
+        saveGameItem.setEnabled(currentSavegameActive());
+
+        LoadExtractedSaveGameItem loadGameItem = new LoadExtractedSaveGameItem(() ->
+                saveGameItem.setEnabled(currentSavegameActive()));
+
+        add(saveGameItem);
+        add(loadGameItem);
     }
 
     public class SaveExtractedSaveGameItem extends JMenuItem implements ActionListener {
 
-        public SaveExtractedSaveGameItem() {
+        SaveExtractedSaveGameItem() {
             addActionListener(this);
             setText("Save");
         }
@@ -38,7 +48,10 @@ public class ExtractedSaveGameMenu extends JMenu {
 
     public class LoadExtractedSaveGameItem extends JMenuItem implements ActionListener {
 
-        public LoadExtractedSaveGameItem() {
+        private Handler onClick;
+
+        LoadExtractedSaveGameItem(Handler onClick) {
+            this.onClick = onClick;
             addActionListener(this);
             setText("Load");
         }
@@ -47,9 +60,19 @@ public class ExtractedSaveGameMenu extends JMenu {
         public void actionPerformed(ActionEvent e) {
             try {
                 Savegame.load(savegameFile);
+                ExtractedSavegameHolder.getInstance().setSelectedSavegame(savegameName);
             } catch (ErrorMessageException ex) {
                 JOptionPane.showMessageDialog(MainWindow.getInstance(), ex.getMessage(), ex.getTitle(), JOptionPane.ERROR_MESSAGE);
             }
+            onClick.handle();
         }
+    }
+
+    private boolean currentSavegameActive() {
+        return ExtractedSavegameHolder.getInstance().getSelectedSavegame().equals(savegameName);
+    }
+
+    private interface Handler {
+        void handle();
     }
 }

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractorMenu.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractorMenu.java
@@ -1,0 +1,15 @@
+package nl.paulinternet.gtasaveedit.view.menu.extractor;
+
+import javax.swing.*;
+
+public class ExtractorMenu extends JMenu {
+
+    public static final int SERVER_ITEM_IDX = 0;
+    public static final int STOP_ITEM_IDX = 1;
+    public static final int EXTRACTED_SAVEGAMES_START_IDX = 2;
+
+    public ExtractorMenu() {
+        super("Savegame Extractor");
+        add(new ServerItem(this), SERVER_ITEM_IDX);
+    }
+}

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractorMenu.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ExtractorMenu.java
@@ -4,12 +4,13 @@ import javax.swing.*;
 
 public class ExtractorMenu extends JMenu {
 
-    public static final int SERVER_ITEM_IDX = 0;
-    public static final int STOP_ITEM_IDX = 1;
-    public static final int EXTRACTED_SAVEGAMES_START_IDX = 2;
-
     public ExtractorMenu() {
         super("Savegame Extractor");
-        add(new ServerItem(this), SERVER_ITEM_IDX);
+        ServerItem serverItem = new ServerItem(this);
+        ServerItem.StopServerItem stopServerItem = serverItem.getStopServerItem();
+
+        add(serverItem);
+        add(stopServerItem);
+        addSeparator();
     }
 }

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ServerItem.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ServerItem.java
@@ -1,0 +1,61 @@
+package nl.paulinternet.gtasaveedit.view.menu.extractor;
+
+import nl.paulinternet.gtasaveedit.extractor.ExtractorServer;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class ServerItem extends JMenuItem implements ActionListener {
+
+    private boolean active = false;
+    private ExtractorServer serverThread = null;
+    private ExtractorMenu menu;
+    private final StopServerItem stopServerItem;
+
+    ServerItem(ExtractorMenu menu) {
+        super("Start Server...");
+        this.menu = menu;
+        addActionListener(this);
+        stopServerItem = new StopServerItem();
+        toggleActive(serverThread != null);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (!active) {
+            serverThread = new ExtractorServer(menu);
+            serverThread.setUncaughtExceptionHandler((t, ex) -> {
+                System.err.println("Uncaught exception in thread '" + t.getName() + "'");
+                ex.printStackTrace();
+            });
+            serverThread.start();
+            toggleActive(true);
+        }
+    }
+
+    private void toggleActive(boolean active) {
+        this.setEnabled(!active);
+        this.active = active;
+        this.setText((active) ? "Server running..." : "Start server");
+        if(active) {
+            menu.add(stopServerItem, ExtractorMenu.STOP_ITEM_IDX);
+        } else {
+            menu.remove(stopServerItem);
+        }
+    }
+
+    public class StopServerItem extends JMenuItem implements ActionListener {
+
+        StopServerItem() {
+            super("Stop server");
+            addActionListener(this);
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            serverThread.stopServer();
+            toggleActive(false);
+        }
+    }
+}

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ServerItem.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/menu/extractor/ServerItem.java
@@ -38,11 +38,7 @@ public class ServerItem extends JMenuItem implements ActionListener {
         this.setEnabled(!active);
         this.active = active;
         this.setText((active) ? "Server running..." : "Start server");
-        if(active) {
-            menu.add(stopServerItem, ExtractorMenu.STOP_ITEM_IDX);
-        } else {
-            menu.remove(stopServerItem);
-        }
+        stopServerItem.setEnabled(active);
     }
 
     public class StopServerItem extends JMenuItem implements ActionListener {
@@ -57,5 +53,9 @@ public class ServerItem extends JMenuItem implements ActionListener {
             serverThread.stopServer();
             toggleActive(false);
         }
+    }
+
+    public StopServerItem getStopServerItem() {
+        return stopServerItem;
     }
 }

--- a/src/main/java/nl/paulinternet/gtasaveedit/view/swing/NewBoxLayout.java
+++ b/src/main/java/nl/paulinternet/gtasaveedit/view/swing/NewBoxLayout.java
@@ -30,7 +30,7 @@ public class NewBoxLayout implements LayoutManager2
 		}
 	}
 	
-	private class Item
+	private static class Item
 	{
 		private Component comp;
 		private int expand;


### PR DESCRIPTION
This PR adds a simple HTTPServer to the savegame editor that can be activated by using the accompanying menu:

<img width="436" alt="Screenshot of the Savegame Extractor menu" src="https://user-images.githubusercontent.com/5144843/48674785-63dae100-eb50-11e8-8e18-67af7a86cc0b.png">

When launched the server will allocate a random port and register as mDNS service with the type of `_gtasa-se._tcp`. 

[A client (for example for Android)](https://github.com/gtasa-savegame-editor/savegame-extractor-android) can use this to send savegames (for example from mobile/consoles) to the editor and let the user edit them (and obviously also download them after editing).

The following HTTP Endpoints are currently implemented:
- `/upload` (will probably be removed) Dummy Upload Form
- `/list` lists currently uploaded savegames
- `/get/<savegame>` returns a savegame (use `/list` to get names)
- `/add` requires `POST` method and multipart upload. Any file part will be handled as savegame