### PR TITLE
Version comparison flags

### DIFF
--- a/savegame-editor/src/main/java/nl/paulinternet/gtasaveedit/view/updater/Version.java
+++ b/savegame-editor/src/main/java/nl/paulinternet/gtasaveedit/view/updater/Version.java
@@ -115,29 +115,28 @@ public class Version implements Comparable<Version> {
     }
 
     /**
-     * Simple {@link Comparable#compareTo(Object)} that checks {@link #major}, {@link #minor}, {@link #patch}.
-     * When the numbers are equal the output of {@link #compareFlags(Flag)} is returned.
+     * Compares the two Version objects. First the {@link #major} and {@link #minor} versions are compared,
+     * then the {@link #flag} version using {@link #compareFlags(Flag)}, and finally the {@link #patch} version.
      *
      * @param o the version to compare to.
      * @return 1 if greater, 0 if equal, -1 if smaller.
      */
     @Override
     public int compareTo(Version o) {
-        if (major == o.major &&
-                minor == o.minor &&
-                patch == o.patch) {
+        if (major != o.major) {
+            return Integer.compare(major, o.major);
+        } else if (minor != o.minor) {
+            return Integer.compare(minor, o.minor);
+        } else if (compareFlags(o.flag) != 0) {
             return compareFlags(o.flag);
-        } else if ((major > o.major) ||
-                ((major == o.major) && (minor > o.minor)) ||
-                ((major == o.major) && (minor == o.minor) && (patch > o.patch))) {
-            return 1;
-        } else {
-            return -1;
+        } else if (patch != o.patch) {
+            return Integer.compare(patch, o.patch);
         }
+        return 0;
     }
 
     /**
-     * Compares version flags according to {@link Comparable#compareTo(Object)} logic.
+     * Compares version flags in the following order from lowest to highest: beta, rc, release.
      *
      * @param otherFlag the flag to compare to.
      * @return 1 if the other flag is "smaller", 0 if the flags are equal, -1 if the other flag is greater.
@@ -146,11 +145,11 @@ public class Version implements Comparable<Version> {
     private int compareFlags(Flag otherFlag) {
         if (flag.equals(otherFlag)) {
             return 0;
-        } else if ((flag.equals(Flag.BETA))) {
+        } else if (flag.equals(Flag.BETA)) {
             if (otherFlag.equals(Flag.RC) || otherFlag.equals(Flag.RELEASE)) {
                 return -1;
             }
-        } else if ((flag.equals(Flag.RC))) {
+        } else if (flag.equals(Flag.RC)) {
             if (otherFlag.equals(Flag.BETA)) {
                 return 1;
             } else if (otherFlag.equals(Flag.RELEASE)) {
@@ -225,10 +224,7 @@ public class Version implements Comparable<Version> {
             return false;
         } else {
             Version o = (Version) obj;
-            return major == o.major &&
-                    minor == o.minor &&
-                    patch == o.patch &&
-                    flag.equals(o.flag);
+            return compareTo(o) == 0;
         }
     }
 }

--- a/savegame-editor/src/test/java/nl/paulinternet/libsavegame/view/updater/VersionTests.java
+++ b/savegame-editor/src/test/java/nl/paulinternet/libsavegame/view/updater/VersionTests.java
@@ -72,6 +72,17 @@ public class VersionTests extends TestCase {
         assertTrue(newerStableVersion.compareTo(newerMajorVersion) < 0);
     }
 
+    public void testEquals() throws Exception {
+        Version stableVersion = new Version("v1.0.0");
+        Version stableVersion1 = new Version("v1.0.0");
+        Version betaVersion = new Version("v1.0-beta.1");
+        Object otherObject = new Object();
+
+        assertEquals(stableVersion, stableVersion1);
+        assertNotSame(stableVersion, betaVersion);
+        assertNotSame(stableVersion, otherObject);
+    }
+
     private void expectException(Handler handler) {
         Exception ex = null;
         try {

--- a/savegame-editor/src/test/java/nl/paulinternet/libsavegame/view/updater/VersionTests.java
+++ b/savegame-editor/src/test/java/nl/paulinternet/libsavegame/view/updater/VersionTests.java
@@ -41,22 +41,40 @@ public class VersionTests extends TestCase {
     }
 
     public void testCompareTo() throws Exception {
-        Version stableVersion = new Version("v1.0.0");
         Version betaVersion = new Version("v1.0-beta.1");
-        Version rcVersion = new Version("v1.0-rc.1");
         Version newerBetaVersion = new Version("v1.0-beta.2");
+        Version rcVersion = new Version("v1.0-rc.1");
+        Version newerRcVersion = new Version("v1.0-rc.10");
+        Version stableVersion = new Version("v1.0.0");
         Version newerStableVersion = new Version("v1.1.0");
+        Version newerMajorVersion = new Version("v2.0.0");
 
-        assertTrue(stableVersion.compareTo(betaVersion) < 0);
-        assertTrue(betaVersion.compareTo(rcVersion) < 0);
+        assertEquals(0, betaVersion.compareTo(betaVersion));
+        assertEquals(0, rcVersion.compareTo(rcVersion));
+        assertEquals(0, stableVersion.compareTo(stableVersion));
         assertTrue(betaVersion.compareTo(newerBetaVersion) < 0);
-        assertTrue(stableVersion.compareTo(newerBetaVersion) < 0);
+        assertTrue(betaVersion.compareTo(rcVersion) < 0);
+        assertTrue(betaVersion.compareTo(newerRcVersion) < 0);
+        assertTrue(betaVersion.compareTo(stableVersion) < 0);
+        assertTrue(betaVersion.compareTo(newerStableVersion) < 0);
+        assertTrue(betaVersion.compareTo(newerMajorVersion) < 0);
+        assertTrue(newerBetaVersion.compareTo(rcVersion) < 0);
+        assertTrue(newerBetaVersion.compareTo(newerRcVersion) < 0);
+        assertTrue(newerBetaVersion.compareTo(stableVersion) < 0);
+        assertTrue(newerBetaVersion.compareTo(newerStableVersion) < 0);
+        assertTrue(newerBetaVersion.compareTo(newerMajorVersion) < 0);
+        assertTrue(rcVersion.compareTo(newerRcVersion) < 0);
+        assertTrue(rcVersion.compareTo(stableVersion) < 0);
+        assertTrue(rcVersion.compareTo(newerStableVersion) < 0);
+        assertTrue(rcVersion.compareTo(newerMajorVersion) < 0);
         assertTrue(stableVersion.compareTo(newerStableVersion) < 0);
+        assertTrue(stableVersion.compareTo(newerMajorVersion) < 0);
+        assertTrue(newerStableVersion.compareTo(newerMajorVersion) < 0);
     }
 
     private void expectException(Handler handler) {
         Exception ex = null;
-        try{
+        try {
             handler.handle();
         } catch (Exception e) {
             ex = e;


### PR DESCRIPTION
Closes #38 

Add a few unit tests and fix the version comparison by considering the flag version before the patch one.